### PR TITLE
fix(docs): render nested objects in payloads and responses

### DIFF
--- a/content/code-examples/subscribers/update-preference.md
+++ b/content/code-examples/subscribers/update-preference.md
@@ -11,7 +11,7 @@ export const novu = new Novu('<REPLACE_WITH_API_KEY_FROM_ADMIN_PANEL>');
 
 await novu.subscribers.updatePreference(user.id, templateId, {
   channel: {
-    type: 'fcm',
+    type: 'email',
     enabled: true,
   },
   enabled: true,

--- a/src/utils/build-properties.js
+++ b/src/utils/build-properties.js
@@ -1,0 +1,22 @@
+import getValueForParameter from './get-value-for-parameter';
+
+export const buildProperty = (propertyName, property) => `
+    ${propertyName}: ${getValueForParameter(property, property.type, propertyName)}`;
+
+export const buildPropertyFromAllOf = (propertyName, property, allOf) => {
+  const { properties } = allOf[0];
+
+  const renderedProperties = Object.keys(properties).map((propertyName) => {
+    const property = properties[propertyName];
+
+    if (property.allOf) {
+      return buildPropertyFromAllOf(propertyName, property, property.allOf);
+    }
+
+    return buildProperty(propertyName, property);
+  });
+
+  return `
+  ${propertyName}: {${renderedProperties}
+  }`;
+};

--- a/src/utils/generate-responses.jsx
+++ b/src/utils/generate-responses.jsx
@@ -1,4 +1,20 @@
-import getValueForParameter from './get-value-for-parameter';
+import { buildPropertyFromAllOf, buildProperty } from './build-properties';
+
+const renderProperties = (properties) =>
+  Object.keys(properties).map((propertyName) => {
+    const property = properties[propertyName];
+
+    if (property.allOf) {
+      return buildPropertyFromAllOf(propertyName, property, property.allOf);
+    }
+
+    return buildProperty(propertyName, property);
+  });
+
+const buildContent = (properties) =>
+  `{
+    ${renderProperties(properties)}
+}`;
 
 const generateResponses = (responses) => {
   const items = responses
@@ -17,15 +33,7 @@ const generateResponses = (responses) => {
         return {
           label: `${response.status}`,
           language: 'json',
-          content: `{
-    ${Object.keys(props)
-      .map((propertyName) => {
-        const { type } = props[propertyName];
-
-        return `${propertyName}: ${getValueForParameter(props[propertyName], type, propertyName)}`;
-      })
-      .join(',\n    ')}
-}`,
+          content: buildContent(props),
         };
       }
 


### PR DESCRIPTION
Render nested objects in payloads and responses and tidy up code.
Not fully rendering the objects in the payloads are causing confusion in our users that read the documentation and the API docs. This should help them.
Unfortunately has been very hard to keep proper alignment in the rendering of the template literals. 🙁 

BEFORE
<img width="1011" alt="Screenshot 2023-02-01 at 04 42 43" src="https://user-images.githubusercontent.com/18152036/215952508-3c4066e8-4b32-4a63-b1db-17d31cefeefd.png">

AFTER
<img width="994" alt="Screenshot 2023-02-01 at 04 42 05" src="https://user-images.githubusercontent.com/18152036/215952532-42f0ef2d-ccc8-4a28-afbb-9891b33f74e8.png">
