### PR TITLE
Add More SDKs to Client libraries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-GATSBY_DEFAULT_SITE_URL=http://localhost:8000
-GATSBY_DEV_SSR=false
-#GATSBY_NOVU_API_URL=http://localhost:3000 // Uncomment this for local development
-#NOVU_API_URL=http://localhost:3000 // Uncomment this for local development

--- a/content/pages/api-reference/client-libraries/client-libraries.md
+++ b/content/pages/api-reference/client-libraries/client-libraries.md
@@ -6,5 +6,9 @@ sort: 3
 
 Novu offers native SDK in several popular programming languages:
 
-- [Go Lang](https://github.com/novuhq/go-novu)
+- [Go](https://github.com/novuhq/go-novu)
 - [Node.js](https://github.com/novuhq/novu/tree/main/packages/node)
+- [PHP](https://github.com/novuhq/novu-php)
+- [Ruby](https://github.com/novuhq/novu-ruby)
+- [Kotlin](https://github.com/novuhq/novu-kotlin)
+- [Python](https://github.com/novuhq/novu-python)


### PR DESCRIPTION
- Add PHP, Python, Kotlin, and Ruby SDKs to the list of SDKs we offer to developers.